### PR TITLE
General drivers code improvements

### DIFF
--- a/drivers/gpu/drm/msm/dsi-staging/dsi_panel.c
+++ b/drivers/gpu/drm/msm/dsi-staging/dsi_panel.c
@@ -708,24 +708,27 @@ static u32 interpolate(uint32_t x, uint32_t xa, uint32_t xb, uint32_t ya, uint32
 u32 dsi_panel_get_fod_dim_alpha(struct dsi_panel *panel)
 {
 	u32 brightness = dsi_panel_get_backlight(panel);
-	int i;
+	int i, alpha;
 
 	if (!panel->fod_dim_lut)
-		return 0;
+		alpha = 0;
 
 	for (i = 0; i < panel->fod_dim_lut_count; i++)
 		if (panel->fod_dim_lut[i].brightness >= brightness)
 			break;
 
 	if (i == 0)
-		return panel->fod_dim_lut[i].alpha;
+		alpha = panel->fod_dim_lut[0].alpha;
 
-	if (i == panel->fod_dim_lut_count)
-		return panel->fod_dim_lut[i - 1].alpha;
-
-	return interpolate(brightness,
-			panel->fod_dim_lut[i - 1].brightness, panel->fod_dim_lut[i].brightness,
-			panel->fod_dim_lut[i - 1].alpha, panel->fod_dim_lut[i].alpha);
+	else if (i == panel->fod_dim_lut_count)
+		alpha = panel->fod_dim_lut[brightness - 1].alpha;
+	else
+		alpha = interpolate(brightness,
+				panel->fod_dim_lut[i - 1].brightness,
+				panel->fod_dim_lut[i].brightness,
+				panel->fod_dim_lut[i - 1].alpha,
+				panel->fod_dim_lut[i].alpha);
+	return alpha;
 }
 
 int dsi_panel_update_doze(struct dsi_panel *panel) {

--- a/drivers/input/touchscreen/fts_521/fts.c
+++ b/drivers/input/touchscreen/fts_521/fts.c
@@ -3127,10 +3127,9 @@ static void fts_enter_pointer_event_handler(struct fts_ts_info *info,
 
 	input_mt_report_slot_state(info->input_dev, tool, 1);
 	input_report_key(info->input_dev, BTN_TOUCH, touch_condition);
-	if (touch_condition)
-		input_report_key(info->input_dev, BTN_TOOL_FINGER, 1);
-
-	/*input_report_abs(info->input_dev, ABS_MT_TRACKING_ID, touchId); */
+		if (touch_condition)
+			input_report_key(info->input_dev, BTN_TOOL_FINGER, 1);
+		/*input_report_abs(info->input_dev, ABS_MT_TRACKING_ID, touchId); */
 		input_report_abs(info->input_dev, ABS_MT_POSITION_X, x);
 		input_report_abs(info->input_dev, ABS_MT_POSITION_Y, y);
 		input_report_abs(info->input_dev, ABS_MT_TOUCH_MINOR, z);

--- a/drivers/input/touchscreen/fts_521/fts.c
+++ b/drivers/input/touchscreen/fts_521/fts.c
@@ -3165,15 +3165,6 @@ static void fts_enter_pointer_event_handler(struct fts_ts_info *info,
 		"%s  %s :  Event 0x%02x - ID[%d], (x, y, z) = (%3d, %3d, %3d) type = %d, size = %d, overlap:%d\n",
 		tag, __func__, *event, touchId, x, y, z, touchType, area_size,
 		info->fod_overlap);
-	if (event[0] == 0x13)
-		logError(1,
-			"%s  %s :  Event 0x%02x - Press ID[%d] type = %d\n", tag,
-				__func__, event[0], touchId, touchType);
-
-#ifndef CONFIG_FTS_FOD_AREA_REPORT
-no_report:
-	return;
-#endif
 }
 
 /**
@@ -3292,11 +3283,7 @@ static void fts_leave_pointer_event_handler(struct fts_ts_info *info,
 			__func__, touchId, touchType);
 	else
 #endif
-		logError(1,
-			"%s  %s :  Event 0x%02x - release ID[%d] type = %d\n", tag,
-			__func__, event[0], touchId, touchType);
-
-	input_sync(info->input_dev);
+     input_sync(info->input_dev);
 #ifdef CONFIG_FTS_FOD_AREA_REPORT
 exit:
 #endif

--- a/drivers/input/touchscreen/fts_521/fts.c
+++ b/drivers/input/touchscreen/fts_521/fts.c
@@ -5829,8 +5829,7 @@ static int fts_probe(struct spi_device *client)
 	int retval;
 	int skip_5_1 = 0;
 	u16 bus_type;
-	u8 *tp_maker;
-
+	
 	logError(1, "%s %s: driver ver: %s\n", tag, __func__,
 		 FTS_TS_DRV_VERSION);
 
@@ -6183,13 +6182,6 @@ static int fts_probe(struct spi_device *client)
 		logError(1, "%s Error: can not create /proc file! \n", tag);
 	info->dbclick_count = 0;
 
-	tp_maker = kzalloc(20, GFP_KERNEL);
-	if (tp_maker == NULL)
-		logError(1, "%s fail to alloc vendor name memory\n", tag);
-	else {
-		kfree(tp_maker);
-		tp_maker = NULL;
-	}
 	device_init_wakeup(&client->dev, 1);
 
 	init_completion(&info->pm_resume_completion);


### PR DESCRIPTION
touchscreen: fts_521: fix a misleading indentation warning (normally detected by compiler)
fts_521: stop flooding the logs (This floods dmesg while touching the screen)
fts_521: remove memory allocation (This memory allocation is not in use currently)
drm: msm: refactor dsi_panel_get_fod_dim_alpha (Just a minnor change to benefit your fod implementation)